### PR TITLE
Remove type button for plot as polygon

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 						<!-- Plots as Polygons -->
 						<div class="col-6" style="padding-left:7.5px;">
 							<div class="col border rounded shadow-sm bg-white">
-								<div class="row form-heading bg-secondary text-white rounded-top p-2 pl-3 active" type="button" data-toggle="collapse" data-target="#plots-as-polygons-box">Plots as Polygons</div>
+								<div class="row form-heading bg-secondary text-white rounded-top p-2 pl-3 active" data-toggle="collapse" data-target="#plots-as-polygons-box">Plots as Polygons</div>
 
 								<div id="plots-as-polygons-box" class="row p-3 collapse">
 									<input id="polygon-plots" class="mr-3" type="checkbox" name="polygon-plots" value="True"><label for="polygon-plots"> make plots polygons</label>


### PR DESCRIPTION
by having the type as button, certain browsers have a different styling that did not fit the rest of the site.