### PR TITLE
Adjust cell side to dataset

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -142,6 +142,11 @@ require(['catiline'], function(cw) {
             lc.addOverlay(L.geoJson(e[0], options).addTo(m), e[1]);
             m.fitBounds(L.geoJson(e[0], options).getBounds());
 
+            // Adjust cell side for scale of data
+            var bbox = turf.bbox(geoJSON);
+            var bboxArea = turf.area(turf.bboxPolygon(bbox));
+            document.getElementById("cell-side").value = Math.round(Math.sqrt(bboxArea)/20);
+
         });
         worker.on('error', function(e) {
             console.warn(e);


### PR DESCRIPTION
Adjust the size of the cell side based on the uploaded data. This way large scale datasets don't generate so many polygons that the browser freezes. The current formula is rough but stops the app from freezing.