### PR TITLE
Show hull on map for points as AOI

### DIFF
--- a/js/sampleplotter.js
+++ b/js/sampleplotter.js
@@ -74,7 +74,8 @@ function genPlots(inJSON) {
 
 	// If inJSON is not polygon
 	if (!["Polygon","MultiPolygon",""].includes(inJSON.features[0].geometry.type)) {
-		inJSON = turf.concave(turf.flatten(readGeoJSON(inJSON)));
+		// Create concave hull containing points
+		inJSON = turf.featureCollection([turf.concave(turf.flatten(readGeoJSON(inJSON)))]);
 	}
 
 	var n = Number(document.getElementById("sample-number").value);
@@ -169,7 +170,7 @@ function genPlots(inJSON) {
 	document.getElementById('point-number').innerHTML = outJSON.features.length;
 
 	// Export and Display on Map
-	exportAndDisplay(inJSON,outJSON)
+	exportAndDisplay(outJSON)
 }
 	
 function displayOnMap(outJSON) {
@@ -367,7 +368,7 @@ function triangleGrid(inJSON,n,bbox,mask) {
 	return features
 }
 
-function exportAndDisplay (inJSON,outJSON) {
+function exportAndDisplay (outJSON) {
 	var json = JSON.stringify(outJSON);
 	var blob = new Blob([json], {type: "application/json"});
 	var url  = URL.createObjectURL(blob)

--- a/js/script.js
+++ b/js/script.js
@@ -147,6 +147,22 @@ require(['catiline'], function(cw) {
             var bboxArea = turf.area(turf.bboxPolygon(bbox));
             document.getElementById("cell-side").value = Math.round(Math.sqrt(bboxArea)/20);
 
+            // If uploaded data are points
+            if (!["Polygon","MultiPolygon",""].includes(geoJSON.features[0].geometry.type)) {
+
+                // Create concave hull containing points
+                hull = turf.featureCollection([turf.concave(turf.flatten(readGeoJSON(geoJSON)))]);
+        
+                // Add hull polygon to map
+                var polygonStyle = {
+                    "color": "#ffffff",
+                    "weight": 3,
+                    "opacity": 0.01
+                };
+                hullLayer = L.geoJson([hull], {style: polygonStyle});
+                hullLayer.addTo(m);
+            }
+
         });
         worker.on('error', function(e) {
             console.warn(e);


### PR DESCRIPTION
When points are uploaded, map will show the concave hull containing the points that is used for generating plots. Example below.

<img width="513" alt="image" src="https://user-images.githubusercontent.com/10215346/199157081-71700206-ab8b-4763-8d57-d9fa7beea3aa.png">
